### PR TITLE
fix random test failure (hopefully) and ignore linting in changelog

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,6 @@
 {
 	"extension": ["ts"],
 	"spec": "test/**/*.spec.ts",
-	"node-option": ["loader=ts-node/esm"]
+	"node-option": ["loader=ts-node/esm"],
+	"timeout": 30000
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@
 /**/templates
 .env
 package-lock.json
+CHANGELOG.md

--- a/test/app.spec.ts
+++ b/test/app.spec.ts
@@ -215,7 +215,7 @@ describe('nodecg:app', () => {
 
 	describe('react', () => {
 		before(function (done) {
-			this.timeout(10000);
+			this.timeout(20000);
 			this.answers = {
 				name: 'react-bundle',
 				typescript: true,

--- a/test/app.spec.ts
+++ b/test/app.spec.ts
@@ -37,7 +37,6 @@ describe('nodecg:app', () => {
 
 	describe('running on new project', () => {
 		before(function (done) {
-			this.timeout(10000);
 			this.answers = {
 				name: 'test-bundle',
 				description: 'A NodeCG bundle',
@@ -131,7 +130,6 @@ describe('nodecg:app', () => {
 
 	describe('typescript', () => {
 		before(function (done) {
-			this.timeout(10000);
 			this.answers = {
 				name: 'typescript-bundle',
 				typescript: true,
@@ -208,14 +206,13 @@ describe('nodecg:app', () => {
 
 		it('generates an actually buildable bundle', async function () {
 			// Increase timeout because npm install (and build) can take some time...
-			this.timeout(130000);
+			this.timeout(300000); // 5 minutes
 			await checkBuild();
 		});
 	});
 
 	describe('react', () => {
 		before(function (done) {
-			this.timeout(20000);
 			this.answers = {
 				name: 'react-bundle',
 				typescript: true,


### PR DESCRIPTION
In my last tests at least always fails at the react test. (But looking through this repo's history this seems not always to be the case) Probably react just needs a little bit more time because the generator does automatically install the packages and react is not that small ....

So I just increased the timeout and
did 5 testruns, which did not fail a single time anymore.

Furthermore, added Changelog to linting ignore as discussed in: https://github.com/nodecg/generator-nodecg/issues/81

Also, please trigger a new npm release after this, so people installing the generator via npm can actually get a working one again ;)