### PR TITLE
fix: make @types/react and @types/react-dom dev dependencies

### DIFF
--- a/src/generators/app/index.ts
+++ b/src/generators/app/index.ts
@@ -310,7 +310,7 @@ export default class AppGenerator extends Generator {
 			
 			if (this.props.react) {
 				await this.addDependencies(['react', 'react-dom']);
-				await this.addDependencies(['@types/react', '@types/react-dom']);
+				await this.addDevDependencies(['@types/react', '@types/react-dom']);
 			}
 		}
 


### PR DESCRIPTION
Changes types to be devDependencies properly instead of direct dependencies.

Fixes issue #97